### PR TITLE
fix: use eigenlayer instead of eigen layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ A curated list of resources to become aligned 🟩
 - [Ethereum for everyone](https://ethereum.org/en/layer-2/) - Ethereum L2s.
 - [Ethereum community hub](https://ethereum.org/en/community/)
 
-## Eigen Layer
+## EigenLayer
 
 - [EigenLayer: The Restaking Collective](https://docs.eigenlayer.xyz/assets/files/EigenLayer_WhitePaper-88c47923ca0319870c611decd6e562ad.pdf) - EigenLayer white paper.
 - [You Could've Invented EigenLayer](https://www.blog.eigenlayer.xyz/ycie/)
 - [EigenLayer Docs](https://docs.eigenlayer.xyz/eigenlayer/overview/)
-- [Eigen Layer Core contracts](https://github.com/Layr-Labs/eigenlayer-contracts)
+- [EigenLayer Core contracts](https://github.com/Layr-Labs/eigenlayer-contracts)
 
 ## Aligned Layer
 


### PR DESCRIPTION
Reviewing the EigenLayer documentation, it can be appreciated that EigenLayer is repeatedly written without a space, not as Eigen Layer. Upon noticing this, the modification was made in this repository.